### PR TITLE
Be able to work with different environments without a rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:13
+# Builder
+FROM node:13 as builder
 
-ADD . /celostats-frontend
-WORKDIR /celostats-frontend
+ADD . /app
+WORKDIR /app
 
 # prepare
 RUN yarn
-RUN yarn global add serve
 
 # build
 ENV NODE_ENV=production
@@ -14,5 +14,15 @@ RUN yarn build
 # clean
 RUN rm -rf ./src ./e2e ./node_modules
 
-EXPOSE 5000
-CMD ["serve", "-s", "./dist"]
+# Server
+FROM nginx:latest
+EXPOSE 80
+RUN apt-get update -y \
+  && apt-get install curl -y \
+  && curl -sL https://deb.nodesource.com/setup_12.x | /bin/bash - \
+  && apt-get install -y nodejs \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/dist/ /var/www/app
+COPY scripts/ /var/www/scripts
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+ENTRYPOINT /var/www/scripts/set-env-variables.js /var/www/app && nginx -g "daemon off;"; /bin/bash

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 0.0.0.0:80;
+  charset utf-8;
+  keepalive_timeout 5;
+
+  location / {
+    root /var/www/app;
+    try_files $uri $uri/ /index.html =404;
+    autoindex on;
+  }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,9 +3,14 @@ server {
   charset utf-8;
   keepalive_timeout 5;
 
+  gzip on;
+
   location / {
     root /var/www/app;
     try_files $uri $uri/ /index.html =404;
     autoindex on;
+    gzip_static on;
+    add_header Cache-Control "max-age=86400, must-revalidate, s-maxage=2592000";
+    add_header Pragma public;
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "ng test --no-watch --code-coverage",
     "test:watch": "ng test --code-coverage",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "set:variables": "scripts/set-env-variables.js ./dist"
   },
   "private": true,
   "dependencies": {

--- a/scripts/set-env-variables.js
+++ b/scripts/set-env-variables.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ENV_VARIABLES = ['ETHSTATS_SERVICE', 'BLOCKSCOUT_URL', 'GRAPHQL_BLOCKSCOUT_URL'];
+
+function promiseify(fn) {
+  return function() {
+    const args = [].slice.call(arguments, 0);
+    return new Promise((resolve, reject) => {
+      fn.apply(this, args.concat([function (err, value) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(value);
+        }
+      }]));
+    });
+  };
+}
+
+const readFile = promiseify(fs.readFile);
+const writeFile = promiseify(fs.writeFile);
+
+function inlineResources(globs) {
+  if (typeof globs == 'string') {
+    globs = [globs];
+  }
+
+  return Promise.all(globs.map(dir => {
+    const files = fs.readdirSync(dir)
+      .filter(name => /\.js$/.test(name))
+      .map(name => `${dir}/${name}`);
+
+    return Promise.all(files.map(filePath => {
+      return readFile(filePath, 'utf-8')
+        .then(content => {
+          ENV_VARIABLES
+            .forEach(variable => {
+              const value = process.env[variable]
+              if (value) {
+                content = content.replace(`%%DOCKER_ENV%%${variable}%%`, value)
+              }
+            })
+          return content
+        })
+        .then(content => writeFile(filePath, content))
+        .catch(err => {
+          console.error('An error occurred: ', err);
+        });
+    }));
+  }));
+}
+
+if (require.main === module) {
+  inlineResources(process.argv.slice(2));
+}
+
+module.exports = inlineResources;

--- a/src/environments/docker-env.ts
+++ b/src/environments/docker-env.ts
@@ -1,0 +1,9 @@
+export const DOCKER_ENV = {
+  ethstatsService: '%%DOCKER_ENV%%ETHSTATS_SERVICE%%',
+  blockscoutUrl: '%%DOCKER_ENV%%BLOCKSCOUT_URL%%',
+  graphqlBlockscoutUrl: '%%DOCKER_ENV%%GRAPHQL_BLOCKSCOUT_URL%%',
+}
+
+Object.entries(DOCKER_ENV)
+  .filter(([variable, value]) => value.match(/%%DOCKER_ENV%%/))
+  .forEach(([variable]) => delete DOCKER_ENV[variable])

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,8 @@
+import { DOCKER_ENV } from './docker-env'
+
 export const environment = {
   production: true,
-  ethstatsService: 'wss://baklava-ethstats.celo-testnet.org',
-  blockscoutUrl: 'https://baklava-blockscout.celo-testnet.org',
-  graphqlBlockscoutUrl: 'https://baklava-blockscout.celo-testnet.org/graphiql',
+  ethstatsService: DOCKER_ENV.ethstatsService || 'wss://baklava-ethstats.celo-testnet.org',
+  blockscoutUrl: DOCKER_ENV.blockscoutUrl || 'https://baklava-blockscout.celo-testnet.org',
+  graphqlBlockscoutUrl: DOCKER_ENV.graphqlBlockscoutUrl || 'https://baklava-blockscout.celo-testnet.org/graphiql',
 }

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, user-scalable=no">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300|Roboto+Mono:400,500,700|Roboto:300,400,700&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined&display=swap" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
We can define the following variables (and its current default values):

- `ETHSTATS_SERVICE`: wss://baklava-ethstats.celo-testnet.org
- `BLOCKSCOUT_URL`: https://baklava-blockscout.celo-testnet.org
- `GRAPHQL_BLOCKSCOUT_URL`: https://baklava-blockscout.celo-testnet.org/graphiql